### PR TITLE
Publish npm releases with trusted OIDC

### DIFF
--- a/.github/workflows/prod.action.yml
+++ b/.github/workflows/prod.action.yml
@@ -4,35 +4,53 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   npmjs-publish:
+    name: Publish to npm
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: npm
-      - run: npm ci
-      - run: npm run test:all
-      - uses: JS-DevTools/npm-publish@v4
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-  gh-packages-publish:
-    runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
-      packages: write
+      id-token: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js for npmjs
+        uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: npm
-      - run: npm ci
-      - run: npm run test:all
-      - uses: JS-DevTools/npm-publish@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          registry: "https://npm.pkg.github.com"
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Validate tag matches package version
+        if: github.event_name == 'push'
+        run: |
+          expected="v$(node -p "require('./package.json').version")"
+          if [ "$GITHUB_REF_NAME" != "$expected" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match package version $expected"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run quality gates
+        run: npm run test:all
+
+      - name: Verify package contents
+        run: npm pack --dry-run
+
+      - name: Publish package to npmjs
+        run: npm publish --access public

--- a/package.json
+++ b/package.json
@@ -18,7 +18,11 @@
   "homepage": "https://github.com/dills122/nedb",
   "repository": {
     "type": "git",
-    "url": "git@github.com:dills122/nedb.git"
+    "url": "git+https://github.com/dills122/nedb.git"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
     "@yetzt/binary-search-tree": "^0.2.6",


### PR DESCRIPTION
## Summary

- replace long-lived `NPM_TOKEN` publishing with npm trusted publishing through GitHub Actions OIDC
- scope `id-token: write` to the npm publish job and disable persisted checkout credentials
- validate release tags, run the full test suite, and inspect the package before publishing
- add manual dispatch so the already-tagged v1.9.2 release can be completed without moving the public tag
- remove the GitHub Packages job, which cannot publish the `@dills1220` scope from the `dills122` GitHub owner
- normalize npm repository and public registry metadata

## npm trusted publisher configuration

- Provider: GitHub Actions
- Organization or user: `dills122`
- Repository: `nedb`
- Workflow filename: `prod.action.yml`
- Environment: none
- Allowed action: `npm publish`

Reference: https://docs.npmjs.com/trusted-publishers/

## Verification

- `npm run test:all` on Node.js 24: 329 passing, 1 pending; integration passing
- workflow YAML parsed successfully
- npm 11.17.0 satisfies trusted publishing's npm 11.5.1 minimum
- `npm pack --dry-run --json`: 20 intended distributable files
- `git diff --check`
